### PR TITLE
fix(): webserver path should be simply localhost:3000

### DIFF
--- a/chapter-11/07-arduino-uno-weather/index.js
+++ b/chapter-11/07-arduino-uno-weather/index.js
@@ -2,9 +2,8 @@ const five     = require('johnny-five');
 const express  = require('express');
 const SocketIO = require('socket.io');
 
-const path = require('path');
 const http = require('http');
-const os   = require('os');
+const path = require('path');
 
 const app    = new express();
 const server = new http.Server(app);
@@ -29,6 +28,6 @@ board.on('ready', () => {
   });
 
   server.listen(3000, () => {
-    console.log(`http://${os.networkInterfaces().wlan0[0].address}:3000`);
+    console.log(`http://localhost:3000`);
   });
 });


### PR DESCRIPTION
On my mac I cannot run webserver of example 07 chapter 11, because of different network interfaces.
As a web developer I suggest to simply use localhost:3000 with nodejs for development purposes.